### PR TITLE
fix: Fix build issue with TypeScript rollup task

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "test": "npm install && npm test",
+    "build": "npm install && npm run build"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Logger.cjs.js",
   "module": "lib/Logger.esm.js",
   "browser": "lib/Logger.umd.min.js",
-  "types": "lib/declarations/Logger.d.ts",
+  "types": "lib/Logger.d.ts",
   "files": [
     "lib"
   ],
@@ -13,11 +13,11 @@
     ".": {
       "import": {
         "default": "./lib/Logger.esm.js",
-        "types": "./lib/declarations/Logger.d.ts"
+        "types": "./lib/Logger.d.ts"
       },
       "require": {
         "default": "./lib/Logger.cjs.js",
-        "types": "./lib/declarations/Logger.d.ts"
+        "types": "./lib/Logger.d.ts"
       }
     },
     "./Logger.umd.js": "./lib/Logger.umd.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,7 +17,7 @@ export default [
         sourcemap: true
       },
     ],
-    plugins: [typescript()],
+    plugins: [typescript({ declarationDir: 'lib' })],
   },
   {
     input: 'src/Logger.ts',
@@ -28,7 +28,7 @@ export default [
       exports: 'named',
       sourcemap: true
     },
-    plugins: [typescript()],
+    plugins: [typescript({ declarationDir: 'lib' })],
   },
   {
     input: 'src/Logger.ts',
@@ -39,6 +39,6 @@ export default [
       exports: 'named',
       sourcemap: true
     },
-    plugins: [typescript(),terser()],
+    plugins: [typescript({ declarationDir: 'lib' }), terser()],
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
       "module": "ESNext",                                  /* Specify what module code is generated. */
       "moduleResolution": "bundler",                        /* Specify how TypeScript looks up a file from a given module specifier. */
       "outDir": "lib",                                     /* Specify an output folder for all emitted files. */
-      "declarationDir": "./lib/declarations",               /* Output directory for generated declaration files. */
+      "declarationDir": "./lib",               /* Output directory for generated declaration files. */
     }
 }


### PR DESCRIPTION
Fix the build process to correctly place declaration files in the output directory specified by TypeScript.

* **tsconfig.json**
  - Change `declarationDir` option to `./lib`.

* **rollup.config.mjs**
  - Update `typescript` plugin configuration to include `declarationDir` set to `lib`.
  - Ensure the `typescript` plugin configuration is consistent across all output formats.

* **package.json**
  - Update `types` field to reference `lib/Logger.d.ts`.
  - Update `exports` field to reference `lib/Logger.d.ts`.

* **.devcontainer.json**
  - Add a new file with tasks for testing and building the project.

